### PR TITLE
Make super dummies not die when they take more than 100 damage

### DIFF
--- a/NPCs/SuperDummy.cs
+++ b/NPCs/SuperDummy.cs
@@ -15,6 +15,7 @@ namespace Fargowiltas.NPCs
         public override void SetDefaults()
         {
             npc.CloneDefaults(NPCID.TargetDummy);
+            npc.lifeMax = int.MaxValue;
             npc.aiStyle = -1;
             npc.width = 28;
             npc.height = 50;


### PR DESCRIPTION
Increase the max hp of a super dummy to int.MaxValue so they don't instantly die upon taking more than 100 damage