### PR TITLE
itemCollections length set to ShopGroup length, fixes Squirrel bug

### DIFF
--- a/NPCs/Squirrel.cs
+++ b/NPCs/Squirrel.cs
@@ -384,7 +384,7 @@ namespace Fargowiltas.NPCs
 
         private List<int> GetSellableItems()
         {
-            List<int>[] itemCollections = new List<int>[6]; //so they can be grouped by category
+            List<int>[] itemCollections = new List<int>[Enum.GetNames(typeof(ShopGroup)).Length - 1]; //so they can be grouped by category
             for (int i = 0; i < itemCollections.Length; i++)
                 itemCollections[i] = new List<int>();
 


### PR DESCRIPTION
the squirrel couldn't be interacted with at all after commit 860611a81ca18e8eed57b1aa9336edf9088070d0 because of the new entry in ShopGroup, causing an index out of bounds error