### PR TITLE
fix clients not being able to join a server

### DIFF
--- a/Items/CaughtNPCs/CaughtNPCItem.cs
+++ b/Items/CaughtNPCs/CaughtNPCItem.cs
@@ -186,12 +186,34 @@ namespace Fargowiltas.Items.CaughtNPCs
 
     public class CaughtGlobalNPC : GlobalNPC
     {
+        private static HashSet<int> npcCatchableWasFalse;
+
+        public override void Load()
+        {
+            npcCatchableWasFalse = new HashSet<int>();
+        }
+
+        public override void Unload()
+        {
+            foreach (var type in npcCatchableWasFalse)
+            {
+                //Failing to unload this properly causes it to bleed into un-fargowiltas gameplay, causing various issues such as clients not being able to join a server
+                Main.npcCatchable[type] = false;
+            }
+            npcCatchableWasFalse = null;
+        }
+
         public override void SetDefaults(NPC npc)
         {
-            if (CaughtNPCItem.CaughtTownies.ContainsKey(npc.type) && ModContent.GetInstance<FargoConfig>().CatchNPCs)
+            int type = npc.type;
+            if (CaughtNPCItem.CaughtTownies.ContainsKey(type) && ModContent.GetInstance<FargoConfig>().CatchNPCs)
             {
-                npc.catchItem = (short)CaughtNPCItem.CaughtTownies.FirstOrDefault(x => x.Key.Equals(npc.type)).Value;
-                Main.npcCatchable[npc.type] = true;
+                npc.catchItem = (short)CaughtNPCItem.CaughtTownies.FirstOrDefault(x => x.Key.Equals(type)).Value;
+                if (!Main.npcCatchable[type])
+                {
+                    npcCatchableWasFalse.Add(type);
+                    Main.npcCatchable[type] = true;
+                }
             }
         }
     }

--- a/Items/CaughtNPCs/CaughtNPCItem.cs
+++ b/Items/CaughtNPCs/CaughtNPCItem.cs
@@ -195,12 +195,15 @@ namespace Fargowiltas.Items.CaughtNPCs
 
         public override void Unload()
         {
-            foreach (var type in npcCatchableWasFalse)
+            if (npcCatchableWasFalse != null)
             {
-                //Failing to unload this properly causes it to bleed into un-fargowiltas gameplay, causing various issues such as clients not being able to join a server
-                Main.npcCatchable[type] = false;
+                foreach (var type in npcCatchableWasFalse)
+                {
+                    //Failing to unload this properly causes it to bleed into un-fargowiltas gameplay, causing various issues such as clients not being able to join a server
+                    Main.npcCatchable[type] = false;
+                }
+                npcCatchableWasFalse = null;
             }
-            npcCatchableWasFalse = null;
         }
 
         public override void SetDefaults(NPC npc)


### PR DESCRIPTION
 ...after mod was enabled->disabled

Currently, the code (under the above mentioned circumstances) causes this dubious exception:
```
[12:54:50.036] [Main Thread/WARN] [tML]: Silently Caught Exception: 
System.IO.EndOfStreamException: Unable to read beyond the end of the stream.
   at System.IO.BinaryReader.Read7BitEncodedInt()
   at Terraria.ModLoader.IO.BitReader..ctor(BinaryReader reader) in tModLoader\Terraria\ModLoader\IO\BitReader.cs:line 14
   at Terraria.ModLoader.NPCLoader.ReceiveExtraAI(NPC npc, Byte[] extraAI) in tModLoader\Terraria\ModLoader\NPCLoader.cs:line 331
   at Terraria.MessageBuffer.GetData(Int32 start, Int32 length, Int32& messageType) in tModLoader\Terraria\MessageBuffer.cs:line 1395
   at Terraria.NetMessage.CheckBytes(Int32 bufferIndex) in tModLoader\Terraria\NetMessage.cs:line 2237
   at Terraria.Main.DoUpdate(GameTime& gameTime) in tModLoader\Terraria\Main.cs:line 12834
   at Terraria.Main.Update(GameTime gameTime) in tModLoader\Terraria\Main.cs:line 12723
   at Microsoft.Xna.Framework.Game.Tick() in D:\a\tModLoader\tModLoader\FNA\src\Game.cs:line 488
   at Microsoft.Xna.Framework.Game.RunLoop() in D:\a\tModLoader\tModLoader\FNA\src\Game.cs:line 878
   at Microsoft.Xna.Framework.Game.Run() in D:\a\tModLoader\tModLoader\FNA\src\Game.cs:line 419
   at Terraria.Program.LaunchGame_(Boolean isServer) in tModLoader\Terraria\Program.cs:line 231
   at Terraria.Program.LaunchGame(String[] args, Boolean monoArgs) in tModLoader\Terraria\Program.cs:line 192
   at MonoLaunch.<>c__DisplayClass1_0.<Main>b__0() in tModLoader\Terraria\MonoLaunch.cs:line 56
   at System.Threading.Thread.StartCallback()
```