### PR TITLE
Remove Omnistation ingredient group

### DIFF
--- a/FargoRecipes.cs
+++ b/FargoRecipes.cs
@@ -250,9 +250,6 @@ namespace Fargowiltas
             group = new RecipeGroup(() => AnyItem("CaughtNPC"), CaughtNPCItem.CaughtTownies.Values.ToArray());
             RecipeGroup.RegisterGroup("Fargowiltas:AnyCaughtNPC", group);
 
-            group = new RecipeGroup(() => AnyItem(ModContent.ItemType<Omnistation>()), ModContent.ItemType<Omnistation>(), ModContent.ItemType<Omnistation2>());
-            RecipeGroup.RegisterGroup("Fargowiltas:AnyOmnistation", group);
-
             group = new RecipeGroup(() => AnyItem(ItemID.CookingPot), ItemID.CookingPot, ItemID.Cauldron);
             RecipeGroup.RegisterGroup("Fargowiltas:AnyCookingPot", group);
 


### PR DESCRIPTION
The Omnistation currently claims to be a material, despite not being used in any recipe. I believe the ingredient group removed in this patch is to blame for that; removing the group should prevent the material tooltip from appearing in the item description