### PR TITLE
Make Shellphone (Home) Usable with Magic Mirror Auto-Use

### DIFF
--- a/FargoPlayer.cs
+++ b/FargoPlayer.cs
@@ -386,6 +386,7 @@ namespace Fargowiltas
                     case ItemID.MagicMirror:
                     case ItemID.IceMirror:
                     case ItemID.CellPhone:
+                    case ItemID.Shellphone:
                         magicMirror = i;
                         break;
                 }


### PR DESCRIPTION
Self-explanatory.

Only uses Shellphone (Home), other destinations are different item IDs.