### PR TITLE
AutoHouse unhardcoded and CaughtNPCItem fix

### DIFF
--- a/Items/CaughtNPCs/CaughtNPCItem.cs
+++ b/Items/CaughtNPCs/CaughtNPCItem.cs
@@ -98,7 +98,7 @@ namespace Fargowiltas.Items.CaughtNPCs
 
         public override bool? UseItem(Player player)
         {
-            return true;
+            return null;
         }
 
         public static void RegisterItems()


### PR DESCRIPTION
Moved logic for getting the tile types and furniture styles for instahouse placing to their own method, allowing other mods to detour the method and set the materials the houses are made of
CaughtNPCItem.UseItem returns null instead of true, fixing an issue where using the item once would spawn 1 npc but use 2 of the item if the player's held stack had more than 1