### PR TITLE
Fixed incorrect usage of Item.wingSlot & used recommended Player.GetWingStats

### DIFF
--- a/Items/FargoGlobalItem.cs
+++ b/Items/FargoGlobalItem.cs
@@ -576,7 +576,7 @@ namespace Fargowiltas.Items
         public override void VerticalWingSpeeds(Item item, Player player, ref float ascentWhenFalling, ref float ascentWhenRising, ref float maxCanAscendMultiplier, ref float maxAscentMultiplier, ref float constantAscend)
         {
             player.GetModPlayer<FargoPlayer>().StatSheetMaxAscentMultiplier = maxAscentMultiplier;
-            player.GetModPlayer<FargoPlayer>().CanHover = ArmorIDs.Wing.Sets.Stats[item.wingSlot].HasDownHoverStats || ArmorIDs.Wing.Sets.Stats[player.wingsLogic].HasDownHoverStats;
+            player.GetModPlayer<FargoPlayer>().CanHover = player.GetWingStats(player.wingsLogic).HasDownHoverStats;
         }
 
         public override void HorizontalWingSpeeds(Item item, Player player, ref float speed, ref float acceleration)


### PR DESCRIPTION
`Player.equippedWings.wingSlot` is not used to determine whether or not the player can hover.