### PR TITLE
Fixed rare crash when entering subworlds in multiplayer

### DIFF
--- a/FargoWorld.cs
+++ b/FargoWorld.cs
@@ -191,7 +191,8 @@ namespace Fargowiltas
         {
             foreach (string tag in tags)
             {
-                DownedBools[tag] = reader.ReadBoolean();
+                if (DownedBools.ContainsKey(tag))
+                    DownedBools[tag] = reader.ReadBoolean();
             }
 
             AbomClearCD = reader.ReadInt32();
@@ -206,7 +207,8 @@ namespace Fargowiltas
         {
             foreach (string tag in tags)
             {
-                writer.Write(DownedBools[tag]);
+                if (DownedBools.TryGetValue(tag, out bool down))
+                    writer.Write(down);
             }
 
             writer.Write(AbomClearCD);

--- a/Localization/en-US.hjson
+++ b/Localization/en-US.hjson
@@ -313,9 +313,21 @@ Mods: {
 
 			SeasonSelections: {
 				Tooltip: ""
-				Normal.Label: Normal
-				AlwaysOn.Label: Always On
-				AlwaysOff.Label: Always Off
+
+				Normal: {
+					Label: Normal
+					Tooltip: ""
+				}
+
+				AlwaysOn: {
+					Label: Always On
+					Tooltip: ""
+				}
+
+				AlwaysOff: {
+					Label: Always Off
+					Tooltip: ""
+				}
 			}
 
 			Common.CanSpawn: Can Spawn

--- a/Localization/pt-BR.hjson
+++ b/Localization/pt-BR.hjson
@@ -313,9 +313,21 @@ Mods: {
 
 			SeasonSelections: {
 				Tooltip: ""
-				Normal.Label: Normal
-				AlwaysOn.Label: Sempre ligado
-				AlwaysOff.Label: Sempre desligado
+
+				Normal: {
+					Label: Normal
+					// Tooltip: ""
+				}
+
+				AlwaysOn: {
+					Label: Sempre ligado
+					// Tooltip: ""
+				}
+
+				AlwaysOff: {
+					Label: Sempre desligado
+					// Tooltip: ""
+				}
 			}
 
 			Common.CanSpawn: Pode aparecer

--- a/Localization/ru-RU.hjson
+++ b/Localization/ru-RU.hjson
@@ -313,9 +313,21 @@ Mods: {
 
 			SeasonSelections: {
 				Tooltip: ""
-				Normal.Label: Обычный
-				AlwaysOn.Label: Всегда вкл.
-				AlwaysOff.Label: Всегда выкл.
+
+				Normal: {
+					Label: Обычный
+					// Tooltip: ""
+				}
+
+				AlwaysOn: {
+					Label: Всегда вкл.
+					// Tooltip: ""
+				}
+
+				AlwaysOff: {
+					Label: Всегда выкл.
+					// Tooltip: ""
+				}
 			}
 
 			Common.CanSpawn: может приходить

--- a/Localization/zh-Hans.hjson
+++ b/Localization/zh-Hans.hjson
@@ -321,9 +321,21 @@ Mods: {
 
 			SeasonSelections: {
 				Tooltip: ""
-				Normal.Label: 正常
-				AlwaysOn.Label: 常开
-				AlwaysOff.Label: 常关
+
+				Normal: {
+					Label: 正常
+					// Tooltip: ""
+				}
+
+				AlwaysOn: {
+					Label: 常开
+					// Tooltip: ""
+				}
+
+				AlwaysOff: {
+					Label: 常关
+					// Tooltip: ""
+				}
 			}
 
 			Common.CanSpawn: 可以生成


### PR DESCRIPTION
It seems this is not fundamentally the fault of mutant mod but there's also just no reason not to add a simple safety check regardless so why not